### PR TITLE
Add installation of PG operator

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -35,14 +35,14 @@ to quickly create a Cobra application.`,
 			fmt.Println(err)
 			os.Exit(1)
 		}
-		if err := cli.ProvisionPMM(); err != nil {
-			fmt.Println(err)
-			os.Exit(1)
-		}
-		//if err := cli.ProvisionCluster(); err != nil {
+		//if err := cli.ProvisionPMM(); err != nil {
 		//	fmt.Println(err)
 		//	os.Exit(1)
 		//}
+		if err := cli.ProvisionCluster(); err != nil {
+			fmt.Println(err)
+			os.Exit(1)
+		}
 	},
 }
 

--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -106,6 +106,18 @@ func (c *CLI) ProvisionCluster() error {
 		return err
 	}
 	c.l.Info("DBaaS operator has been installed")
+	c.l.Info("Installing PG operator")
+	channel, ok = os.LookupEnv("DBAAS_PG_OP_CHANNEL")
+	if !ok || channel == "" {
+		channel = "stable-v2"
+	}
+	params.Name = "percona-postgresql-operator"
+	params.Channel = channel
+	if err := c.kubeClient.InstallOperator(ctx, params); err != nil {
+		c.l.Error("failed installing PG operator")
+		return err
+	}
+	c.l.Info("PG operator has been installed")
 	if c.config.Monitoring.Enabled {
 		c.l.Info("Started setting up monitoring")
 		if err := c.provisionPMMMonitoring(); err != nil {


### PR DESCRIPTION
As there is still no `stable-v2`, in order for the installation to succeed one shall set the `DBAAS_PG_OP_CHANNEL=fast-v2` env var.